### PR TITLE
FIX: any type bug on api.helper

### DIFF
--- a/src/api/api.helper.ts
+++ b/src/api/api.helper.ts
@@ -2,6 +2,7 @@ export const getContentType = () => ({
   "Content-Type": "application/json",
 })
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const errorCatch = (error: any): string => {
   const message = error?.response?.data?.message
 


### PR DESCRIPTION
FIX: any type bug on api.helper

## Summary by Sourcery

Bug Fixes:
- Resolve type safety issue by explicitly allowing 'any' type for error handling in API helper function